### PR TITLE
First logout the user and only then show the alert

### DIFF
--- a/app/views/account/rpiframe.html.erb
+++ b/app/views/account/rpiframe.html.erb
@@ -32,7 +32,7 @@
       if (e.origin !== target_origin) { return alert('Wrong target origin: ' + target_origin); }
       stat = e.data;
 
-      let current_time = Date.now();
+      let current_time = Date.now() / (1000*60);
       if (stat == "changed" && (!alerted || (current_time - last_alert) > 60)) {
         alerted = true;
         last_alert = Date.now() / (1000*60);

--- a/app/views/account/rpiframe.html.erb
+++ b/app/views/account/rpiframe.html.erb
@@ -26,9 +26,9 @@
       stat = e.data;
 
       if (stat == "changed" && !alerted) {
-        window.alert("Your session is not valid. Please copy your changes and refresh the page to login.");
         alerted = true
         window.location.href = window.location.origin + "/logout";
+        window.alert("Your session is not valid. Please copy your changes and refresh the page to login.");
       }
     }
   </script>

--- a/app/views/account/rpiframe.html.erb
+++ b/app/views/account/rpiframe.html.erb
@@ -11,7 +11,14 @@
     var target_origin = new URL("<%= @oic_session.client_config['openid_connect_server_url'] %>").origin;
     var session_state = "<%= @oic_session.session_state %>";
     var alerted = false;
+    var last_alert = 0;
 
+    // Create an iframe used to logout user if their session has expired
+    var logout_iframe = document.createElement("iframe");
+    logout_iframe.style.display = "none";
+    logout_iframe.setAttribute("id", "logout_iframe");
+    window.parent.document.head.appendChild(logout_iframe);
+    
     var mes = client_id + " " + session_state;
     var timer = setInterval(checkSession(), check_interval);
 
@@ -25,9 +32,13 @@
       if (e.origin !== target_origin) { return alert('Wrong target origin: ' + target_origin); }
       stat = e.data;
 
-      if (stat == "changed" && !alerted) {
-        alerted = true
-        window.location.href = window.location.origin + "/logout";
+      let current_time = Date.now();
+      if (stat == "changed" && (!alerted || (current_time - last_alert) > 60)) {
+        alerted = true;
+        last_alert = Date.now() / (1000*60);
+        let logout_iframe = document.getElementById("logout_iframe");
+        logout_iframe.setAttribute("src", window.location.origin + "/logout");
+        
         window.alert("Your session is not valid. Please copy your changes and refresh the page to login.");
       }
     }

--- a/app/views/account/rpiframe.html.erb
+++ b/app/views/account/rpiframe.html.erb
@@ -14,7 +14,7 @@
     var last_alert = 0;
 
     // Create an iframe used to logout user if their session has expired
-    var logout_iframe = document.createElement("iframe");
+    let logout_iframe = document.createElement("iframe");
     logout_iframe.style.display = "none";
     logout_iframe.setAttribute("id", "logout_iframe");
     window.parent.document.head.appendChild(logout_iframe);
@@ -36,8 +36,7 @@
       if (stat == "changed" && (!alerted || (current_time - last_alert) > 60)) {
         alerted = true;
         last_alert = Date.now() / (1000*60);
-        let logout_iframe = document.getElementById("logout_iframe");
-        logout_iframe.setAttribute("src", window.location.origin + "/logout");
+        window.parent.document.getElementById("logout_iframe").setAttribute("src", window.location.origin + "/logout");
         
         window.alert("Your session is not valid. Please copy your changes and refresh the page to login.");
       }


### PR DESCRIPTION
The alert was pausing the script which could cause the user to be logged out after just logging in. Concretely if you have multiple tabs open and your session expires then a pop up is shown in all the open redmine tabs. From this state two issues can occur:
1. If you proceed by reloading the page then you are redirected to the same page with the same notification and are not redirected to the websso to login.
2. If you press okay on the alert and then refresh you can log in again but once you press okay on the alert of another tab you are logged out again.

These two problems are caused because the alert actually halts the execution of the script. This caused the script to only log out the user after they press okay on the alert.

This pr solves the described problems by first logging the user out (in another iframe) and then showing the alert. If the page is not refreshed the alert is shown again after 1 hour.